### PR TITLE
Init leb128 v1.0.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,8 @@
+{% set name = "leb128" %}
 {% set version = "1.0.5" %}
 
 package:
-  name: leb128
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -9,16 +10,17 @@ source:
   sha256: cb16001f0087b499ab51f6b8e3ef8377ba14a0c9990db85316dedf0ad4a54e80
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
   number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.7
+    - python
 
 test:
   imports:
@@ -30,8 +32,16 @@ test:
 
 about:
   home: https://github.com/mohanson/leb128
+  dev_url: https://github.com/mohanson/leb128
+  doc_url: https://github.com/mohanson/leb128#readme
   summary: LEB128(Little Endian Base 128)
+  description: |
+    LEB128 or Little Endian Base 128 is a form of variable-length code
+    compression used to store an arbitrarily large integer in a small number
+    of bytes. LEB128 is used in the DWARF debug file format and the
+    WebAssembly binary encoding for all integer literals.
   license: MIT
+  license_family: MIT
   license_file: LICENSE
 
 extra:


### PR DESCRIPTION
### Overview

**Jira:**
[PKG: 1835](https://anaconda.atlassian.net/browse/PKG-1835) part of the `emscripten` [epic](https://anaconda.atlassian.net/browse/PKG-1819) 

**Changes made:**
- Added Jinja variable for `name` of the package
- Removed the `noarch`
- Added the `--no-build-isolation` flag
- Removed the `python` pinnings
- Added `setuptools` and `wheel` to the `host` section
- Added the `dev_url`, `doc_url`, `description` and `license_family` to the `about` section